### PR TITLE
Make it clearer that extensions can only be installed during initial setup

### DIFF
--- a/docs/extensions/availableExtensions.md
+++ b/docs/extensions/availableExtensions.md
@@ -4,6 +4,10 @@ sidebar_position: 10
 
 # Available Extensions
 
+:::info Hint
+Extensions can only be installed during the initial setup of a new Scaffold-ETH 2 project.
+:::info Hint
+
 ## Core Extensions
 
 Core extensions are extensions built and maintained by Scaffold-ETH 2 team. These extensions can be directly accessed via just extension name without mentioning the github user name and branch name:

--- a/docs/extensions/availableExtensions.md
+++ b/docs/extensions/availableExtensions.md
@@ -4,9 +4,9 @@ sidebar_position: 10
 
 # Available Extensions
 
-:::info Hint
+:::info Info
 Extensions can only be installed during the initial setup of a new Scaffold-ETH 2 project.
-:::info Hint
+:::info Info
 
 ## Core Extensions
 

--- a/docs/extensions/extensions.md
+++ b/docs/extensions/extensions.md
@@ -2,16 +2,16 @@
 sidebar_position: 9
 ---
 
-# 🔌 Starter Extensions
+# 🔌 Extensions
 
-This guide introduces starter extensions for Scaffold-ETH 2 and explains how to install and create them.
+This guide introduces extensions for Scaffold-ETH 2 and explains how to install and create them.
 
-## What are Starter Extensions?
+## What are Extensions?
 
-Starter Extensions are modular add-ons for Scaffold-ETH 2 that provide additional functionality or serve as examples for specific features.
+Extensions are modular add-ons for Scaffold-ETH 2 that provide additional functionality or serve as examples for specific features.
 
-Starter Extensions can only be installed during the initial setup of a new Scaffold-ETH 2 project.
 :::info Info
+Extensions can only be installed during the initial setup of a new Scaffold-ETH 2 project.
 :::info Info
 
 They offer several benefits:

--- a/docs/extensions/extensions.md
+++ b/docs/extensions/extensions.md
@@ -2,23 +2,29 @@
 sidebar_position: 9
 ---
 
-# 🔌 Extensions
+# 🔌 Starter Extensions
 
-This guide introduces extensions for Scaffold-ETH 2 and explains how to use and create extensions.
+This guide introduces starter extensions for Scaffold-ETH 2 and explains how to install and create them.
 
-## What are Extensions?
+## What are Starter Extensions?
 
-Extensions are modular add-ons for Scaffold-ETH 2 that provide additional functionality or serve as examples for specific features. They offer several benefits:
+Starter Extensions are modular add-ons for Scaffold-ETH 2 that provide additional functionality or serve as examples for specific features.
+
+:::info Hint
+Starter Extensions can only be installed during the initial setup of a new Scaffold-ETH 2 project.
+:::info Hint
+
+They offer several benefits:
 
 - Seamless integration with the base Scaffold-ETH 2 project
-- Quick addition of new features, pages, contracts, or components
+- Quick addition of new features, pages, contracts, or components at project creation
 - Compatibility with Scaffold-ETH 2 core updates and improvements
 
 Extensions are compact packages containing specific code (such as a smart contract or UI component) that automatically integrate with the latest version of Scaffold-ETH 2 when initializing a new project via npx. They are starting points for your project, not finished products.
 
-## Using Extensions
+## Installing Extensions
 
-To use an extension when creating a new Scaffold-ETH 2 project, run:
+To install an extension when creating a new Scaffold-ETH 2 project, run:
 
 ```bash
 npx create-eth@latest -e {github-username}/{extension-repo-name}:{branch-name}

--- a/docs/extensions/extensions.md
+++ b/docs/extensions/extensions.md
@@ -10,9 +10,9 @@ This guide introduces starter extensions for Scaffold-ETH 2 and explains how to 
 
 Starter Extensions are modular add-ons for Scaffold-ETH 2 that provide additional functionality or serve as examples for specific features.
 
-:::info Hint
 Starter Extensions can only be installed during the initial setup of a new Scaffold-ETH 2 project.
-:::info Hint
+:::info Info
+:::info Info
 
 They offer several benefits:
 


### PR DESCRIPTION
I've only changed the wording of the main section titles to "Starter extensions", because changing the childs titles may feel too repetitive. Also:

- Tried to enforce the idea of installation - initial project in the descriptions and subtitle.
- Added a visual hint in the main section and the `Available Extensions` section.

Closes #82 