### PR TITLE
Added tabs with Foundry installation steps

### DIFF
--- a/docs/quick-start/installation.mdx
+++ b/docs/quick-start/installation.mdx
@@ -3,6 +3,9 @@ sidebar_position: 1
 description: Requirements and installation methods to get started with Scaffold ETH-2.
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Installation
 
 ## Requirements
@@ -57,10 +60,31 @@ For more information about available extensions and how to use them, check out t
 
 ### Option 2: Setup using `git clone`
 
-Clone this repo & install dependencies:
-
+```mdx-code-block
+<Tabs groupId="dev-tool">
+<TabItem value="hardhat" label="Hardhat" default>
 ```
+
+```sh
 git clone https://github.com/scaffold-eth/scaffold-eth-2.git
 cd scaffold-eth-2
 yarn install
 ```
+
+```mdx-code-block
+</TabItem>
+<TabItem value="foundry" label="Foundry">
+```
+
+```sh
+git clone -b foundry --recurse-submodules https://github.com/scaffold-eth/scaffold-eth-2.git 
+cd scaffold-eth-2
+yarn install
+```
+
+</TabItem>
+</Tabs>
+
+Clone this repo & install dependencies:
+
+

--- a/docs/quick-start/installation.mdx
+++ b/docs/quick-start/installation.mdx
@@ -85,6 +85,3 @@ yarn install
 </TabItem>
 </Tabs>
 
-Clone this repo & install dependencies:
-
-


### PR DESCRIPTION
I've added two tabs for hardhat and foundry. I've used same tab groupId than Environment page.

![image](https://github.com/user-attachments/assets/565ca8c7-74a3-45fa-8aeb-0736e8d2e9c9)
![image](https://github.com/user-attachments/assets/6ce35375-2ec3-431f-a25c-84b23af40498)

In Foundry case I've used this `--recurse-submodules` to download `lib/` content, so with `git clone` and `foundry install` was not working for me... 