### PR TITLE
Add eip-5792 extension

### DIFF
--- a/docs/extensions/availableExtensions.md
+++ b/docs/extensions/availableExtensions.md
@@ -25,6 +25,7 @@ Here are the core extensions:
 - [onchainkit](https://github.com/scaffold-eth/create-eth-extensions/tree/onchainkit): Pre-configured with [onchainkit](https://onchainkit.xyz/),providing an example to help you get started quickly with the ready-to-use React components and TypeScript utilities built by Coinbase team.
 - [erc-20](https://github.com/scaffold-eth/create-eth-extensions/tree/erc-20): An implementation of ERC-20 token contract, allowing you to interact with the contract in a user-friendly manner, including getting a holder balance and transferring tokens.
 - [eip-712](https://github.com/scaffold-eth/create-eth-extensions/tree/eip-712): An implementation of EIP-712, allowing you to send, sign, and verify typed messages.
+- [eip-5792](https://github.com/scaffold-eth/create-eth-extensions/tree/eip-5792): An implementation of EIP-5792 wallet capabilities, allowing you to use the new JSON-RPC methods for sending multiple calls from the user wallet, and checking their status.
 
 ## Third-party Extensions
 


### PR DESCRIPTION
Adding the new curated extension to the docs:

![image](https://github.com/user-attachments/assets/5dbc2cd7-4bd1-41b5-b038-afc53f542c32)

Can check it [here](https://scaffold-eth-2-docs-git-eip5792-buidlguidldao.vercel.app/extensions/availableExtensions)