### PR TITLE
Remove clone method

### DIFF
--- a/docs/quick-start/installation.mdx
+++ b/docs/quick-start/installation.mdx
@@ -15,16 +15,7 @@ Before you begin, you need to install the following tools:
 
 ## Setup
 
-To get started with Scaffold-ETH 2, you have two options:
-
-1. Use the npx command: `npx create-eth@latest` to bootstrap the project directly.
-2. Use git clone to clone the repository.
-
-### Option 1: Setup using `npx create-eth@latest`
-
-For a simplified setup, Scaffold-ETH 2 offers a npx method that guides you interactively through the setup.
-
-Bootstrap the project:
+For a simplified setup, Scaffold-ETH 2 offers a npx tool that guides you interactively through the setup:
 
 ```
 npx create-eth@latest
@@ -32,9 +23,8 @@ npx create-eth@latest
 
 You will be presented with a series of prompts:
 
-- **Project Name:** Input your project name: Enter a name for your project, e.g., my-dapp-example.
-- **Solidity Framework** What solidity framework do you want to use?: Choose your preferred solidity framework (Hardhat, Foundry)
-- **Install packages?:** Press `Enter` for `yes` (default option) or type `n` and press `Enter` for no
+- **Project Name:** Enter a name for your project, e.g., my-dapp-example.
+- **Solidity Framework** Choose your preferred solidity framework (Hardhat, Foundry)
 
 Once the setup is complete, navigate to the project directory:
 
@@ -53,14 +43,4 @@ If you want to use extensions, you can add the -e flag followed by the extension
 npx create-eth@latest -e extension-name
 ```
 
-For more information about available extensions and how to use them, check out the Extensions section.
-
-### Option 2: Setup using `git clone`
-
-Clone this repo & install dependencies:
-
-```
-git clone https://github.com/scaffold-eth/scaffold-eth-2.git
-cd scaffold-eth-2
-yarn install
-```
+For more information about available extensions and how to use them, check out the [Extensions section](/extensions)


### PR DESCRIPTION
As we discussed yesterday, we are moving away from SE-2 clone method. The first step is to remove it from the docs / READMEs / etc.

Also:
- tweaked copy a bit
- link to extension section

Related
https://github.com/scaffold-eth/scaffoldeth.io/pull/41
https://github.com/scaffold-eth/scaffold-eth-2/pull/993