### PR TITLE
Explain Foundry keystore in `Generate a new account` section

### DIFF
--- a/docs/deploying/deploy-smart-contracts.mdx
+++ b/docs/deploying/deploy-smart-contracts.mdx
@@ -82,7 +82,21 @@ You will get prompted to paste your private key and set the encryption password.
 <TabItem value="foundry" label="Foundry">
 ```
 
-If you prefer to manually set your own private key, you will need to add `DEPLOYER_PRIVATE_KEY=yourWalletPrivateKey` to `packages/foundry/.env`.
+It will automatically generate a new keystore under the name `scaffold-eth-custom`.
+
+You will be prompted to enter a password which will be used to encrypt your keystore. **Make sure to remember this password as you'll need it for future deployments and account queries.**
+
+Now you need to open your `packages/foundry/.env` file, and update `ETH_KEYSTORE_ACCOUNT = scaffold-eth-custom` to start using the new keystore.
+
+If you prefer to import your private key (you need to delete your `scaffold-eth-custom` keystore first, if exists), run:
+
+```
+yarn account:import
+```
+
+You will get prompted to paste your private key and set the encryption password. It will store your encrypted private key in the `scaffold-eth-custom` keystore file.
+
+Also if you want to use your existing keystore account you can just update the `ETH_KEYSTORE_ACCOUNT` in your `.env` file, setting the name of your existing account.
 
 </TabItem>
 </Tabs>

--- a/docs/deploying/deploy-smart-contracts.mdx
+++ b/docs/deploying/deploy-smart-contracts.mdx
@@ -90,7 +90,7 @@ It will automatically generate a new keystore under the name `scaffold-eth-custo
 
 You will be prompted to enter a password which will be used to encrypt your keystore. **Make sure to remember this password as you'll need it for future deployments and account queries.**
 
-Now you need to open your `packages/foundry/.env` file, and update `ETH_KEYSTORE_ACCOUNT = scaffold-eth-custom` to start using the new keystore.
+Now you'll need to open your `packages/foundry/.env` file, and update `ETH_KEYSTORE_ACCOUNT = scaffold-eth-custom` to start using the new keystore.
 
 If you prefer to import your private key (you need to delete your `scaffold-eth-custom` keystore first, if exists), run:
 

--- a/docs/deploying/deploy-smart-contracts.mdx
+++ b/docs/deploying/deploy-smart-contracts.mdx
@@ -69,6 +69,10 @@ It will automatically add the encrypted private key (`DEPLOYER_PRIVATE_KEY_ENCRY
 
 You will be prompted to enter a password which will be used to encrypt your private key. **Make sure to remember this password as you'll need it for future deployments and account queries.**
 
+:::info Info
+We are only storing the plain private key in memory, it's never stored in disk files for security reasons. Can check the code [here](https://github.com/scaffold-eth/scaffold-eth-2/pull/1008/files).
+:::info
+
 If you prefer to import your private key, run:
 
 ```


### PR DESCRIPTION
- Updates the Foundry tab adding Keystore explanations
- Explains that we are not storing the plan PKs in disk (Hardhat tab)

Closes #91 