### PR TITLE
Add deployment details for hardhat and foundry

### DIFF
--- a/docs/deploying/deploy-smart-contracts.mdx
+++ b/docs/deploying/deploy-smart-contracts.mdx
@@ -149,7 +149,7 @@ To deploy specific contracts instead of all of them, you can follow these steps:
 <TabItem value="hardhat" label="Hardhat" default>
 ```
 
-1. Add tags to the deploy scripts located in `packages/hardhat/deploy`.
+1. Add tags to the deploy scripts located in `packages/hardhat/deploy`. For example `01_deploy_my_contract.ts`:
 
 ```ts
 deployMyContract.tags = ["tagExample"];

--- a/docs/deploying/deploy-smart-contracts.mdx
+++ b/docs/deploying/deploy-smart-contracts.mdx
@@ -115,12 +115,12 @@ You will need to enter your password to decrypt the private key and view the acc
 
 ## 3. Deploy your smart contract(s)
 
-By default `yarn deploy` will deploy contract to the local network. You can change `defaultNetwork` in:
-
 ```mdx-code-block
 <Tabs groupId="dev-tool">
 <TabItem value="hardhat" label="Hardhat" default>
 ```
+
+By default `yarn deploy` will deploy all the contracts from your `packages/hardhat/contracts` folder to the local network. You can change `defaultNetwork` in:
 
 ```sh
 packages/hardhat/hardhat.config.ts
@@ -131,6 +131,8 @@ packages/hardhat/hardhat.config.ts
 <TabItem value="foundry" label="Foundry">
 ```
 
+By default `yarn deploy` will deploy all the contracts from your `packages/foundry/contracts` folder to the local network. You can change `defaultNetwork` in:
+
 ```sh
 packages/foundry/foundry.toml
 ```
@@ -138,13 +140,72 @@ packages/foundry/foundry.toml
 </TabItem>
 </Tabs>
 
+### 3.1 Deploy specific contracts
+
+To deploy specific contracts instead of all your contracts, you can follow these steps:
+
+```mdx-code-block
+<Tabs groupId="dev-tool">
+<TabItem value="hardhat" label="Hardhat" default>
+```
+
+1. Add tags to your deploy script located in `packages/hardhat/deploy`.
+
+```ts
+deployMyContract.tags = ["tagExample"];
+```
+
+2. Run `yarn deploy --tags tagExample` to run all the scripts with the "tagExample" tag.
+
+`````mdx-code-block
+</TabItem>
+<TabItem value="foundry" label="Foundry">
+
+1. Each contract that you wish to deploy individually should have its own deployment script in `packages/foundry/script`. For example: `DeployMyContract.s.sol`
+
+2. Run the specific deployment script using:
+
+```sh
+yarn deploy --file DeployMyContract.s.sol
+```
+If you don't specify the file, it will default to `Deploy.s.sol` file, where you can setup all the contracts to deploy with the `yarn deploy` command.
+
+</TabItem>
+</Tabs>
+
+### 3.2 Deploy to specific networks
+
 Run the command below to deploy the smart contract to the target network. Make sure to have your encryption password and some funds in your deployer account to pay for the transaction.
 
 ```
 yarn deploy --network network_name
 ```
 
-eg: `yarn deploy --network sepolia`
+```mdx-code-block
+<Tabs groupId="dev-tool">
+<TabItem value="hardhat" label="Hardhat" default>
+```
+
+You can also specify a tag:
+
+```sh
+yarn deploy --network sepolia --tags tagExample
+```
+
+````mdx-code-block
+</TabItem>
+<TabItem value="foundry" label="Foundry">
+
+Requires custom keystore setup, see [generate accounts](#2-generate-a-new-account-or-add-one-to-deploy-the-contracts-from)
+
+You can also specify a file:
+
+```sh
+yarn deploy --network sepolia --file DeployMyContract.s.sol
+```
+
+</TabItem>
+</Tabs>
 
 ## 4. Verify your smart contract
 
@@ -209,3 +270,5 @@ For production-grade applications, it's recommended to obtain your own API keys 
 :::tip Hint
 It's recommended to store envs for nextjs in Vercel/system env config for live apps and use .env.local for local testing.
 :::tip Hint
+```
+`````

--- a/docs/deploying/deploy-smart-contracts.mdx
+++ b/docs/deploying/deploy-smart-contracts.mdx
@@ -142,14 +142,14 @@ packages/foundry/foundry.toml
 
 ### 3.1 Deploy specific contracts
 
-To deploy specific contracts instead of all your contracts, you can follow these steps:
+To deploy specific contracts instead of all of them, you can follow these steps:
 
 ```mdx-code-block
 <Tabs groupId="dev-tool">
 <TabItem value="hardhat" label="Hardhat" default>
 ```
 
-1. Add tags to your deploy script located in `packages/hardhat/deploy`.
+1. Add tags to the deploy scripts located in `packages/hardhat/deploy`.
 
 ```ts
 deployMyContract.tags = ["tagExample"];
@@ -168,14 +168,14 @@ deployMyContract.tags = ["tagExample"];
 ```sh
 yarn deploy --file DeployMyContract.s.sol
 ```
-If you don't specify the file, it will default to `Deploy.s.sol` file, where you can setup all the contracts to deploy with the `yarn deploy` command.
+If you don't specify the `--file` parameter, the deployment will use the default `Deploy.s.sol` file. This default file can be configured to deploy multiple contracts in a specific order when you run the `yarn deploy` command.
 
 </TabItem>
 </Tabs>
 
 ### 3.2 Deploy to specific networks
 
-Run the command below to deploy the smart contract to the target network. Make sure to have your encryption password and some funds in your deployer account to pay for the transaction.
+Run the command below to deploy the smart contracts to the target network. Make sure to have your encryption password and some funds in your deployer account to pay for the transaction.
 
 ```
 yarn deploy --network network_name


### PR DESCRIPTION
Tried to explain the content from https://github.com/scaffold-eth/scaffold-eth-2/blob/foundry-imporvements/README.md in a format that feels natural into the `Deploy Your Smart Contracts` section.

Let me know if I missed anything. Feel free to push any tweak/addition/removal 🙌

Closes #106 