### PR TITLE
Separate state from component examples in Inputs

### DIFF
--- a/docs/components/AddressInput.md
+++ b/docs/components/AddressInput.md
@@ -20,8 +20,10 @@ import { AddressInput } from "~~/components/scaffold-eth";
 
 ```tsx
 const [address, setAddress] = useState("");
+```
 
-<AddressInput onChange={setAddress} value={address} placeholder="Input your address" />;
+```tsx
+<AddressInput onChange={setAddress} value={address} placeholder="Input your address" />
 ```
 
 ## Props

--- a/docs/components/EtherInput.md
+++ b/docs/components/EtherInput.md
@@ -18,8 +18,10 @@ import { EtherInput } from "~~/components/scaffold-eth";
 
 ```tsx
 const [ethAmount, setEthAmount] = useState("");
+```
 
-<EtherInput value={ethAmount} onChange={amount => setEthAmount(amount)} />;
+```tsx
+<EtherInput value={ethAmount} onChange={amount => setEthAmount(amount)} />
 ```
 
 ## Props

--- a/docs/components/InputBase.md
+++ b/docs/components/InputBase.md
@@ -18,8 +18,10 @@ import { InputBase } from "~~/components/scaffold-eth";
 
 ```tsx
 const [url, setUrl] = useState<string>();
+```
 
-<InputBase name="url" placeholder="url" value={url} onChange={setUrl} />;
+```tsx
+<InputBase name="url" placeholder="url" value={url} onChange={setUrl} />
 ```
 
 ## Props

--- a/docs/components/IntergerInput.md
+++ b/docs/components/IntergerInput.md
@@ -19,14 +19,16 @@ import { IntegerInput } from "~~/components/scaffold-eth";
 
 ```tsx
 const [txValue, setTxValue] = useState<string | bigint>("");
+```
 
+```tsx
 <IntegerInput
   value={txValue}
   onChange={updatedTxValue => {
     setTxValue(updatedTxValue);
   }}
   placeholder="value (wei)"
-/>;
+/>
 ```
 
 ## Props


### PR DESCRIPTION
### Description: 

Earlier our example looked like this: 

<img width="921" alt="image" src="https://github.com/user-attachments/assets/b5f7a138-14d2-4353-80aa-a7adfe6012ef" />


And the markdown fromatter in docs used to add semicolon `;` automatically at a the end component example since it was not able distinguish b/w plain typescript code and TSX (component)

Separate the state initialization and component example code block. This is also handy when copy pasting things from docs. Since state and component lives at different places in code it's easy to copy and past one by one  

But feel free to suggest any other alternative, no strong opinion on this 🙌  