### PR TITLE
Add vercel login command to `Deploy Your NextJS App` section

### DIFF
--- a/docs/deploying/deploy-nextjs-app.mdx
+++ b/docs/deploying/deploy-nextjs-app.mdx
@@ -15,7 +15,13 @@ If you want to deploy directly from the CLI, run this and follow the steps to de
 yarn vercel
 ```
 
-Once you log in (email, GitHub, etc.), the default options should work. It'll give you a public URL.
+You might need to log in to Vercel first by running:
+
+```
+yarn vercel:login
+```
+
+Once you log in (email, GitHub, etc), the default options should work. It'll give you a public URL.
 
 If you want to redeploy to the same production URL you can run:
 


### PR DESCRIPTION
Adding the new `yarn vercel:login` command needed to be able to log into vercel (required to `yarn vercel`). 

Context: https://github.com/scaffold-eth/scaffold-eth-2/issues/1025
Initial fix: https://github.com/scaffold-eth/scaffold-eth-2/pull/1027