### PR TITLE
Add a hint for :yolo and :yolo --prod

### DIFF
--- a/docs/deploying/deploy-nextjs-app.mdx
+++ b/docs/deploying/deploy-nextjs-app.mdx
@@ -31,6 +31,21 @@ yarn vercel --prod
 
 If you omit the `--prod` flag it will deploy it to a preview/test URL.
 
+:::tip Hint
+If you want to deploy without checking types, you can run:
+
+```
+yarn vercel:yolo
+```
+
+And if you want to deploy to production without checking types, you can run:
+
+```
+yarn vercel:yolo --prod
+```
+
+:::tip Hint
+
 **Make sure to check the values of your Scaffold Configuration before deploying your NextJS App.**
 
 ## Scaffold App Configuration


### PR DESCRIPTION
This PR:

-> Adds :yolo and :yolo --prod combination to the docs as a hint.

<img width="1428" alt="image" src="https://github.com/user-attachments/assets/f6755b35-5854-40a7-9864-76d0a94c9c59" />
